### PR TITLE
[GILJOB-95] 유저 프로필 조회 api

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -136,6 +136,16 @@ include::{snippets}/users/me/get/http-response.adoc[]
 .response fields
 include::{snippets}/users/me/get/response-fields.adoc[]
 
+=== GET /api/users/{userId}/profile
+유저 프로필 조회
+
+.request
+include::{snippets}/users/{userid}/profile/get/http-request.adoc[]
+.response
+include::{snippets}/users/{userid}/profile/get/http-response.adoc[]
+.response fields
+include::{snippets}/users/{userid}/profile/get/response-fields.adoc[]
+
 == Upload API
 === POST /api/upload
 .request

--- a/src/main/kotlin/com/yapp/giljob/domain/quest/application/QuestMapper.kt
+++ b/src/main/kotlin/com/yapp/giljob/domain/quest/application/QuestMapper.kt
@@ -4,7 +4,7 @@ import com.yapp.giljob.domain.quest.dto.response.QuestByParticipantResponseDto
 import com.yapp.giljob.domain.quest.dto.response.QuestResponseDto
 import com.yapp.giljob.domain.quest.vo.QuestSupportVo
 import com.yapp.giljob.domain.user.application.UserMapper
-import com.yapp.giljob.domain.user.vo.UserSubDto
+import com.yapp.giljob.domain.user.dto.response.UserSubResponseDto
 import org.mapstruct.Mapper
 import org.mapstruct.Mapping
 import org.mapstruct.Mappings
@@ -20,7 +20,7 @@ interface QuestMapper {
         Mapping(target = "participantCount", source = "questSupportVo.participantCount"),
         Mapping(target = "user", source = "user")
     )
-    fun toDto(questSupportVo: QuestSupportVo, user: UserSubDto): QuestResponseDto
+    fun toDto(questSupportVo: QuestSupportVo, user: UserSubResponseDto): QuestResponseDto
 
     @Mappings(
         Mapping(target = "id", source = "questSupportVo.quest.id"),
@@ -32,5 +32,5 @@ interface QuestMapper {
         Mapping(target = "user", source = "user"),
         Mapping(target = "progress", source = "progress"),
     )
-    fun toDto(questSupportVo: QuestSupportVo, user: UserSubDto, progress: Int): QuestByParticipantResponseDto
+    fun toDto(questSupportVo: QuestSupportVo, user: UserSubResponseDto, progress: Int): QuestByParticipantResponseDto
 }

--- a/src/main/kotlin/com/yapp/giljob/domain/quest/application/QuestMapper.kt
+++ b/src/main/kotlin/com/yapp/giljob/domain/quest/application/QuestMapper.kt
@@ -3,7 +3,7 @@ package com.yapp.giljob.domain.quest.application
 import com.yapp.giljob.domain.quest.dto.response.QuestByParticipantResponseDto
 import com.yapp.giljob.domain.quest.dto.response.QuestResponseDto
 import com.yapp.giljob.domain.quest.vo.QuestSupportVo
-import com.yapp.giljob.domain.user.dao.UserMapper
+import com.yapp.giljob.domain.user.application.UserMapper
 import com.yapp.giljob.domain.user.vo.UserSubDto
 import org.mapstruct.Mapper
 import org.mapstruct.Mapping

--- a/src/main/kotlin/com/yapp/giljob/domain/quest/application/QuestService.kt
+++ b/src/main/kotlin/com/yapp/giljob/domain/quest/application/QuestService.kt
@@ -8,7 +8,7 @@ import com.yapp.giljob.domain.quest.dto.response.QuestDetailCommonResponseDto
 import com.yapp.giljob.domain.quest.dto.response.QuestResponseDto
 import com.yapp.giljob.domain.subquest.application.SubQuestService
 import com.yapp.giljob.domain.tag.application.TagService
-import com.yapp.giljob.domain.user.dao.UserMapper
+import com.yapp.giljob.domain.user.application.UserMapper
 import com.yapp.giljob.domain.user.domain.User
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional

--- a/src/main/kotlin/com/yapp/giljob/domain/quest/dto/response/QuestByParticipantResponseDto.kt
+++ b/src/main/kotlin/com/yapp/giljob/domain/quest/dto/response/QuestByParticipantResponseDto.kt
@@ -1,13 +1,13 @@
 package com.yapp.giljob.domain.quest.dto.response
 
 import com.yapp.giljob.domain.position.domain.Position
-import com.yapp.giljob.domain.user.vo.UserSubDto
+import com.yapp.giljob.domain.user.dto.response.UserSubResponseDto
 
 class QuestByParticipantResponseDto(
     var id: Long,
     var name: String,
     var position: Position,
-    var user: UserSubDto,
+    var user: UserSubResponseDto,
     var difficulty: Int,
     var progress: Int,
     var thumbnail: String,

--- a/src/main/kotlin/com/yapp/giljob/domain/quest/dto/response/QuestResponseDto.kt
+++ b/src/main/kotlin/com/yapp/giljob/domain/quest/dto/response/QuestResponseDto.kt
@@ -1,13 +1,13 @@
 package com.yapp.giljob.domain.quest.dto.response
 
 import com.yapp.giljob.domain.position.domain.Position
-import com.yapp.giljob.domain.user.vo.UserSubDto
+import com.yapp.giljob.domain.user.dto.response.UserSubResponseDto
 
 class QuestResponseDto(
     var id: Long,
     var name: String,
     var position: Position,
-    var user: UserSubDto,
+    var user: UserSubResponseDto,
     var difficulty: Int,
     var thumbnail: String,
     var participantCount: Long

--- a/src/main/kotlin/com/yapp/giljob/domain/user/api/UserController.kt
+++ b/src/main/kotlin/com/yapp/giljob/domain/user/api/UserController.kt
@@ -3,11 +3,13 @@ package com.yapp.giljob.domain.user.api
 import com.yapp.giljob.domain.user.application.UserService
 import com.yapp.giljob.domain.user.domain.User
 import com.yapp.giljob.domain.user.dto.response.UserInfoResponseDto
+import com.yapp.giljob.domain.user.dto.response.UserProfileResponseDto
 import com.yapp.giljob.global.common.annotation.CurrentUser
 import com.yapp.giljob.global.common.dto.BaseResponse
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
@@ -21,7 +23,17 @@ class UserController(
         return ResponseEntity.ok(
             BaseResponse.of(
                 HttpStatus.OK, "인증된 유저 정보 조회 성공입니다.",
-                userService.getAuthenticatedUserInfo(user)
+                userService.getUserInfo(user)
+            )
+        )
+    }
+
+    @GetMapping("/{userId}/profile")
+    fun getUserProfile(@PathVariable userId: Long): ResponseEntity<BaseResponse<UserProfileResponseDto>> {
+        return ResponseEntity.ok(
+            BaseResponse.of(
+                HttpStatus.OK, "유저 프로필 조회 성공입니다.",
+                userService.getUserProfile(userId)
             )
         )
     }

--- a/src/main/kotlin/com/yapp/giljob/domain/user/application/UserMapper.kt
+++ b/src/main/kotlin/com/yapp/giljob/domain/user/application/UserMapper.kt
@@ -1,10 +1,13 @@
-package com.yapp.giljob.domain.user.dao
+package com.yapp.giljob.domain.user.application
 
+import com.yapp.giljob.domain.user.domain.Ability
 import com.yapp.giljob.domain.user.domain.User
+import com.yapp.giljob.domain.user.dto.response.AbilityResponseDto
 import com.yapp.giljob.domain.user.vo.UserSubDto
 import org.mapstruct.Mapper
 
 @Mapper(componentModel = "spring")
 interface UserMapper {
     fun toDto(user: User, point: Long): UserSubDto
+    fun toDto(ability: Ability): AbilityResponseDto
 }

--- a/src/main/kotlin/com/yapp/giljob/domain/user/application/UserMapper.kt
+++ b/src/main/kotlin/com/yapp/giljob/domain/user/application/UserMapper.kt
@@ -3,11 +3,11 @@ package com.yapp.giljob.domain.user.application
 import com.yapp.giljob.domain.user.domain.Ability
 import com.yapp.giljob.domain.user.domain.User
 import com.yapp.giljob.domain.user.dto.response.AbilityResponseDto
-import com.yapp.giljob.domain.user.vo.UserSubDto
+import com.yapp.giljob.domain.user.dto.response.UserSubResponseDto
 import org.mapstruct.Mapper
 
 @Mapper(componentModel = "spring")
 interface UserMapper {
-    fun toDto(user: User, point: Long): UserSubDto
+    fun toDto(user: User, point: Long): UserSubResponseDto
     fun toDto(ability: Ability): AbilityResponseDto
 }

--- a/src/main/kotlin/com/yapp/giljob/domain/user/application/UserMapper.kt
+++ b/src/main/kotlin/com/yapp/giljob/domain/user/application/UserMapper.kt
@@ -3,11 +3,23 @@ package com.yapp.giljob.domain.user.application
 import com.yapp.giljob.domain.user.domain.Ability
 import com.yapp.giljob.domain.user.domain.User
 import com.yapp.giljob.domain.user.dto.response.AbilityResponseDto
+import com.yapp.giljob.domain.user.dto.response.UserInfoResponseDto
 import com.yapp.giljob.domain.user.dto.response.UserSubResponseDto
 import org.mapstruct.Mapper
+import org.mapstruct.Mapping
+import org.mapstruct.Mappings
 
 @Mapper(componentModel = "spring")
 interface UserMapper {
     fun toDto(user: User, point: Long): UserSubResponseDto
     fun toDto(ability: Ability): AbilityResponseDto
+
+    @Mappings(
+        Mapping(target = "userId", source = "user.id"),
+        Mapping(target = "nickname", source = "user.nickname"),
+        Mapping(target = "intro", source = "user.intro"),
+        Mapping(target = "position", source = "ability.position"),
+        Mapping(target = "point", source = "ability.point")
+    )
+    fun toDto(user: User, ability: AbilityResponseDto): UserInfoResponseDto
 }

--- a/src/main/kotlin/com/yapp/giljob/domain/user/application/UserQuestService.kt
+++ b/src/main/kotlin/com/yapp/giljob/domain/user/application/UserQuestService.kt
@@ -7,7 +7,6 @@ import com.yapp.giljob.domain.quest.dao.QuestRepository
 import com.yapp.giljob.domain.quest.dto.response.QuestByParticipantResponseDto
 import com.yapp.giljob.domain.quest.dto.response.QuestResponseDto
 import com.yapp.giljob.domain.subquest.dao.SubQuestParticipationRepository
-import com.yapp.giljob.domain.user.dao.UserMapper
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 

--- a/src/main/kotlin/com/yapp/giljob/domain/user/application/UserService.kt
+++ b/src/main/kotlin/com/yapp/giljob/domain/user/application/UserService.kt
@@ -2,22 +2,48 @@ package com.yapp.giljob.domain.user.application
 
 import com.yapp.giljob.domain.position.domain.Position
 import com.yapp.giljob.domain.user.dao.AbilityRepository
+import com.yapp.giljob.domain.user.dao.UserRepository
 import com.yapp.giljob.domain.user.domain.User
+import com.yapp.giljob.domain.user.dto.response.AbilityResponseDto
 import com.yapp.giljob.domain.user.dto.response.UserInfoResponseDto
+import com.yapp.giljob.domain.user.dto.response.UserProfileResponseDto
 import com.yapp.giljob.global.error.ErrorCode
 import com.yapp.giljob.global.error.exception.BusinessException
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
 @Service
 class UserService(
+    private val userRepository: UserRepository,
     private val abilityRepository: AbilityRepository,
+
+    private val userMapper: UserMapper
 ) {
     @Transactional(readOnly = true)
-    fun getAuthenticatedUserInfo(user: User) =
-        UserInfoResponseDto(user.id!!, getUserAbility(user.id!!, user.position).point)
+    fun getUserInfo(user: User): UserInfoResponseDto {
+        val ability = getUserAbility(user.id!!, user.position)
+        return UserInfoResponseDto(userId = user.id!!, nickname = user.nickname, position = user.position, point = ability.point)
+    }
+
+    @Transactional(readOnly = true)
+    fun getUserProfile(userId: Long): UserProfileResponseDto {
+        val user = userRepository.findByIdOrNull(userId) ?: throw BusinessException(ErrorCode.ENTITY_NOT_FOUND)
+        return UserProfileResponseDto(
+            userInfo = getUserInfo(user),
+            intro = user.intro,
+            abilityList = getAbilityListByUserId(userId)
+        )
+    }
 
     private fun getUserAbility(userId: Long, position: Position) =
         abilityRepository.findByUserIdAndPosition(userId, position)
             ?: throw BusinessException(ErrorCode.ENTITY_NOT_FOUND)
+
+    private fun getAbilityListByUserId(userId: Long): List<AbilityResponseDto> {
+        val abilityList = abilityRepository.findByUserId(userId)
+        return abilityList.map {
+            userMapper.toDto(it)
+        }
+    }
 }

--- a/src/main/kotlin/com/yapp/giljob/domain/user/application/UserService.kt
+++ b/src/main/kotlin/com/yapp/giljob/domain/user/application/UserService.kt
@@ -23,29 +23,18 @@ class UserService(
     @Transactional(readOnly = true)
     fun getUserInfo(user: User): UserInfoResponseDto {
         val ability = getUserAbility(user.id!!, user.position)
-        return makeUserInfo(user, ability)
+        return userMapper.toDto(user, ability)
     }
 
     @Transactional(readOnly = true)
     fun getUserProfile(userId: Long): UserProfileResponseDto {
         val user = userRepository.findByIdOrNull(userId) ?: throw BusinessException(ErrorCode.ENTITY_NOT_FOUND)
         val abilityList = getAbilityListByUserId(userId)
-        val ability = abilityList.find { it.position == user.position } ?: throw BusinessException(ErrorCode.ENTITY_NOT_FOUND)
+        val ability =
+            abilityList.find { it.position == user.position } ?: throw BusinessException(ErrorCode.ENTITY_NOT_FOUND)
 
-        return UserProfileResponseDto(
-            userInfo = makeUserInfo(user, ability),
-            intro = user.intro,
-            abilityList = abilityList
-        )
+        return UserProfileResponseDto(userInfo = userMapper.toDto(user, ability), abilityList = abilityList)
     }
-
-    private fun makeUserInfo(user: User, ability: AbilityResponseDto) =
-        UserInfoResponseDto(
-            userId = user.id!!,
-            nickname = user.nickname,
-            position = ability.position,
-            point = ability.point
-        )
 
     private fun getUserAbility(userId: Long, position: Position) =
         userMapper.toDto(

--- a/src/main/kotlin/com/yapp/giljob/domain/user/dao/AbilityRepository.kt
+++ b/src/main/kotlin/com/yapp/giljob/domain/user/dao/AbilityRepository.kt
@@ -6,4 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository
 
 interface AbilityRepository: JpaRepository<Ability, Long> {
     fun findByUserIdAndPosition(userId: Long, position: Position): Ability?
+    fun findByUserId(userId: Long): List<Ability>
 }

--- a/src/main/kotlin/com/yapp/giljob/domain/user/dto/response/AbilityResponseDto.kt
+++ b/src/main/kotlin/com/yapp/giljob/domain/user/dto/response/AbilityResponseDto.kt
@@ -2,9 +2,7 @@ package com.yapp.giljob.domain.user.dto.response
 
 import com.yapp.giljob.domain.position.domain.Position
 
-class UserInfoResponseDto(
-    var userId: Long,
-    var nickname: String,
+class AbilityResponseDto(
     var position: Position,
     var point: Long
 )

--- a/src/main/kotlin/com/yapp/giljob/domain/user/dto/response/UserInfoResponseDto.kt
+++ b/src/main/kotlin/com/yapp/giljob/domain/user/dto/response/UserInfoResponseDto.kt
@@ -6,5 +6,6 @@ class UserInfoResponseDto(
     var userId: Long,
     var nickname: String,
     var position: Position,
-    var point: Long
+    var point: Long,
+    var intro: String
 )

--- a/src/main/kotlin/com/yapp/giljob/domain/user/dto/response/UserProfileResponseDto.kt
+++ b/src/main/kotlin/com/yapp/giljob/domain/user/dto/response/UserProfileResponseDto.kt
@@ -1,0 +1,7 @@
+package com.yapp.giljob.domain.user.dto.response
+
+class UserProfileResponseDto(
+    val userInfo: UserInfoResponseDto,
+    val intro: String,
+    val abilityList: List<AbilityResponseDto>
+)

--- a/src/main/kotlin/com/yapp/giljob/domain/user/dto/response/UserProfileResponseDto.kt
+++ b/src/main/kotlin/com/yapp/giljob/domain/user/dto/response/UserProfileResponseDto.kt
@@ -2,6 +2,5 @@ package com.yapp.giljob.domain.user.dto.response
 
 class UserProfileResponseDto(
     val userInfo: UserInfoResponseDto,
-    val intro: String,
     val abilityList: List<AbilityResponseDto>
 )

--- a/src/main/kotlin/com/yapp/giljob/domain/user/dto/response/UserSubResponseDto.kt
+++ b/src/main/kotlin/com/yapp/giljob/domain/user/dto/response/UserSubResponseDto.kt
@@ -1,0 +1,7 @@
+package com.yapp.giljob.domain.user.dto.response
+
+class UserSubResponseDto(
+    var id: Long,
+    var nickname: String,
+    var point: Long
+)

--- a/src/main/kotlin/com/yapp/giljob/domain/user/vo/UserSubDto.kt
+++ b/src/main/kotlin/com/yapp/giljob/domain/user/vo/UserSubDto.kt
@@ -1,7 +1,0 @@
-package com.yapp.giljob.domain.user.vo
-
-class UserSubDto(
-    var id: Long,
-    var nickname: String,
-    var point: Long
-)

--- a/src/main/kotlin/com/yapp/giljob/global/config/security/WebSecurityConfig.kt
+++ b/src/main/kotlin/com/yapp/giljob/global/config/security/WebSecurityConfig.kt
@@ -23,6 +23,7 @@ class WebSecurityConfig(
             "/sign-in",
             "/api/quests/count",
             "/api/users/**/quests/**",
+            "/api/users/**/profile",
             "/don't-pass-filter",
             "/docs/index.html",
             "api/quests/common/**"

--- a/src/main/resources/static/docs/index.html
+++ b/src/main/resources/static/docs/index.html
@@ -1502,7 +1502,7 @@ Content-Length: 238
   "status" : 200,
   "message" : "회원 가입 성공입니다.",
   "data" : {
-    "accessToken" : "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJudWxsIiwiaWF0IjoxNjM4OTY3ODc3LCJleHAiOjI2Mzg5Njc4Nzd9.UUrtLBudz6N54ZxLyAZB-DzqjwUE8ZK9t4ji_hwm5q0"
+    "accessToken" : "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJudWxsIiwiaWF0IjoxNjM5MDU1MjA0LCJleHAiOjI2MzkwNTUyMDR9.NhMwlR8-F1nNEW-f-pfQsMSDdlEv-OR7XjDLOwvhifc"
   }
 }</code></pre>
 </div>
@@ -1572,7 +1572,7 @@ Content-Length: 266
   "message" : "로그인 및 조회 성공입니다.",
   "data" : {
     "isSignedUp" : true,
-    "accessToken" : "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIiwiaWF0IjoxNjM4OTY3ODc2LCJleHAiOjI2Mzg5Njc4NzZ9.v67FT3dtB-jJzSbdb4ZF6nVd0L0PjhnQTHZKAKhSePE"
+    "accessToken" : "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIiwiaWF0IjoxNjM5MDU1MjAzLCJleHAiOjI2MzkwNTUyMDN9.GUTEDAv2ALqemKStiJbel_z9fUPBAMpjBtGUNrJXknA"
   }
 }</code></pre>
 </div>
@@ -1642,7 +1642,7 @@ Host: docs.api.com:8080</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
 Content-Type: application/json;charset=UTF-8
-Content-Length: 197
+Content-Length: 229
 
 {
   "status" : 200,
@@ -1651,7 +1651,8 @@ Content-Length: 197
     "userId" : 1,
     "nickname" : "nickname",
     "position" : "BACKEND",
-    "point" : 1000
+    "point" : 1000,
+    "intro" : "test introduce"
   }
 }</code></pre>
 </div>
@@ -1706,6 +1707,11 @@ Content-Length: 197
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">유저가 설정한 직군에 대한 능력치 포인트(레벨 결정)</p></td>
 </tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.intro</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">유저 자기소개</p></td>
+</tr>
 </tbody>
 </table>
 </div>
@@ -1726,7 +1732,7 @@ Host: docs.api.com:8080</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
 Content-Type: application/json;charset=UTF-8
-Content-Length: 398
+Content-Length: 401
 
 {
   "status" : 200,
@@ -1736,9 +1742,9 @@ Content-Length: 398
       "userId" : 1,
       "nickname" : "nickname",
       "position" : "BACKEND",
-      "point" : 1000
+      "point" : 1000,
+      "intro" : "test introduce"
     },
-    "intro" : "test introduce",
     "abilityList" : [ {
       "position" : "BACKEND",
       "point" : 1000
@@ -1806,7 +1812,7 @@ Content-Length: 398
 <td class="tableblock halign-left valign-top"><p class="tableblock">유저가 설정한 직군에 대한 능력치 포인트</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.intro</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.userInfo.intro</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">유저 자기소개</p></td>
 </tr>
@@ -1926,7 +1932,7 @@ Content-Length: 198
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2021-12-08 21:50:19 +0900
+Last updated 2021-12-09 21:02:53 +0900
 </div>
 </div>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.6/styles/github.min.css">

--- a/src/main/resources/static/docs/index.html
+++ b/src/main/resources/static/docs/index.html
@@ -478,6 +478,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <li><a href="#_user_api">User API</a>
 <ul class="sectlevel2">
 <li><a href="#_get_apiusersme">GET /api/users/me</a></li>
+<li><a href="#_get_apiusersuseridprofile">GET /api/users/{userId}/profile</a></li>
 </ul>
 </li>
 <li><a href="#_upload_api">Upload API</a>
@@ -1501,7 +1502,7 @@ Content-Length: 238
   "status" : 200,
   "message" : "회원 가입 성공입니다.",
   "data" : {
-    "accessToken" : "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJudWxsIiwiaWF0IjoxNjM4ODgwNTg2LCJleHAiOjI2Mzg4ODA1ODZ9.ubsN_wjir0JE4cf7AorMswlNiBejpGx85Va9-sKkHc4"
+    "accessToken" : "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJudWxsIiwiaWF0IjoxNjM4OTY3ODc3LCJleHAiOjI2Mzg5Njc4Nzd9.UUrtLBudz6N54ZxLyAZB-DzqjwUE8ZK9t4ji_hwm5q0"
   }
 }</code></pre>
 </div>
@@ -1571,7 +1572,7 @@ Content-Length: 266
   "message" : "로그인 및 조회 성공입니다.",
   "data" : {
     "isSignedUp" : true,
-    "accessToken" : "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIiwiaWF0IjoxNjM4ODgwNTg1LCJleHAiOjI2Mzg4ODA1ODV9.rQzcOyFtc-7HZOHlYr3Heh8baFAqhAzLcpIC_NbN9bA"
+    "accessToken" : "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIiwiaWF0IjoxNjM4OTY3ODc2LCJleHAiOjI2Mzg5Njc4NzZ9.v67FT3dtB-jJzSbdb4ZF6nVd0L0PjhnQTHZKAKhSePE"
   }
 }</code></pre>
 </div>
@@ -1641,13 +1642,15 @@ Host: docs.api.com:8080</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
 Content-Type: application/json;charset=UTF-8
-Content-Length: 140
+Content-Length: 197
 
 {
   "status" : 200,
   "message" : "인증된 유저 정보 조회 성공입니다.",
   "data" : {
     "userId" : 1,
+    "nickname" : "nickname",
+    "position" : "BACKEND",
     "point" : 1000
   }
 }</code></pre>
@@ -1689,9 +1692,138 @@ Content-Length: 140
 <td class="tableblock halign-left valign-top"><p class="tableblock">현재 유저 id</p></td>
 </tr>
 <tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.nickname</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">유저 닉네임</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.position</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">유저가 설정한 직군(포지션)</p></td>
+</tr>
+<tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.point</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">유저 능력치 포인트(레벨 결정)</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">유저가 설정한 직군에 대한 능력치 포인트(레벨 결정)</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect2">
+<h3 id="_get_apiusersuseridprofile"><a class="link" href="#_get_apiusersuseridprofile">GET /api/users/{userId}/profile</a></h3>
+<div class="paragraph">
+<p>유저 프로필 조회</p>
+</div>
+<div class="listingblock">
+<div class="title">request</div>
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /api/users/1/profile HTTP/1.1
+Host: docs.api.com:8080</code></pre>
+</div>
+</div>
+<div class="listingblock">
+<div class="title">response</div>
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
+Content-Type: application/json;charset=UTF-8
+Content-Length: 398
+
+{
+  "status" : 200,
+  "message" : "유저 프로필 조회 성공입니다.",
+  "data" : {
+    "userInfo" : {
+      "userId" : 1,
+      "nickname" : "nickname",
+      "position" : "BACKEND",
+      "point" : 1000
+    },
+    "intro" : "test introduce",
+    "abilityList" : [ {
+      "position" : "BACKEND",
+      "point" : 1000
+    }, {
+      "position" : "FRONTEND",
+      "point" : 400
+    } ]
+  }
+}</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<caption class="title">Table 16. response fields</caption>
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>status</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">200</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>message</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">성공 메세지</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Object</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 데이터</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.userInfo</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Object</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">유저 정보 조회</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.userInfo.userId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">유저 id</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.userInfo.nickname</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">유저 닉네임</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.userInfo.position</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">유저가 설정한 직군(포지션)</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.userInfo.point</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">유저가 설정한 직군에 대한 능력치 포인트</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.intro</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">유저 자기소개</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.abilityList</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Array</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">유저 능력치 리스트</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.abilityList[*].position</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">유저 포지션</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.abilityList[*].point</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">유저 포지션에 대한 포인트</p></td>
 </tr>
 </tbody>
 </table>
@@ -1704,7 +1836,7 @@ Content-Length: 140
 <div class="sect2">
 <h3 id="_post_apiupload"><a class="link" href="#_post_apiupload">POST /api/upload</a></h3>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 16. request</caption>
+<caption class="title">Table 17. request</caption>
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -1751,7 +1883,7 @@ Content-Length: 198
 </div>
 </div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 17. response fields</caption>
+<caption class="title">Table 18. response fields</caption>
 <colgroup>
 <col style="width: 33.3333%;">
 <col style="width: 33.3333%;">
@@ -1794,7 +1926,7 @@ Content-Length: 198
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2021-12-07 07:59:35 +0900
+Last updated 2021-12-08 21:50:19 +0900
 </div>
 </div>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.6/styles/github.min.css">

--- a/src/test/kotlin/com/yapp/giljob/domain/quest/application/QuestMapperTest.kt
+++ b/src/test/kotlin/com/yapp/giljob/domain/quest/application/QuestMapperTest.kt
@@ -1,7 +1,7 @@
 package com.yapp.giljob.domain.quest.application
 
 import com.yapp.giljob.domain.quest.vo.QuestSupportVo
-import com.yapp.giljob.domain.user.dao.UserMapper
+import com.yapp.giljob.domain.user.application.UserMapper
 import com.yapp.giljob.global.common.domain.EntityFactory
 import com.yapp.giljob.global.common.dto.DtoFactory
 import org.junit.jupiter.api.Assertions.assertEquals

--- a/src/test/kotlin/com/yapp/giljob/domain/quest/application/QuestServiceTest.kt
+++ b/src/test/kotlin/com/yapp/giljob/domain/quest/application/QuestServiceTest.kt
@@ -4,7 +4,7 @@ import com.yapp.giljob.domain.quest.dao.QuestRepository
 import com.yapp.giljob.domain.subquest.application.SubQuestService
 import com.yapp.giljob.domain.tag.application.TagService
 import com.yapp.giljob.domain.tag.domain.QuestTag
-import com.yapp.giljob.domain.user.dao.UserMapper
+import com.yapp.giljob.domain.user.application.UserMapper
 import com.yapp.giljob.global.common.domain.EntityFactory
 import com.yapp.giljob.global.common.dto.DtoFactory
 import io.mockk.MockKAnnotations

--- a/src/test/kotlin/com/yapp/giljob/domain/user/api/UserControllerTest.kt
+++ b/src/test/kotlin/com/yapp/giljob/domain/user/api/UserControllerTest.kt
@@ -3,12 +3,11 @@ package com.yapp.giljob.domain.user.api
 import com.yapp.giljob.domain.user.application.UserService
 import com.yapp.giljob.domain.user.dao.AbilityRepository
 import com.yapp.giljob.domain.user.dao.UserRepository
-import com.yapp.giljob.domain.user.dto.response.UserInfoResponseDto
 import com.yapp.giljob.global.AbstractRestDocs
 import com.yapp.giljob.global.common.domain.EntityFactory
+import com.yapp.giljob.global.common.dto.DtoFactory
 import com.yapp.giljob.global.config.security.GiljobTestUser
 import org.junit.jupiter.api.Test
-import org.mockito.ArgumentMatchers.any
 import org.mockito.BDDMockito
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
 import org.springframework.boot.test.mock.mockito.MockBean
@@ -34,8 +33,8 @@ class UserControllerTest : AbstractRestDocs() {
     @GiljobTestUser
     @Test
     fun getAuthenticatedUserInfoTest() {
-        BDDMockito.given(userService.getAuthenticatedUserInfo(EntityFactory.testUser())).willReturn(
-            UserInfoResponseDto(1L, 1000)
+        BDDMockito.given(userService.getUserInfo(EntityFactory.testUser())).willReturn(
+            DtoFactory.testUserInfoResponse()
         )
 
         val result = mockMvc.perform(
@@ -58,8 +57,60 @@ class UserControllerTest : AbstractRestDocs() {
                             .description("응답 데이터"),
                         PayloadDocumentation.fieldWithPath("data.userId")
                             .description("현재 유저 id"),
+                        PayloadDocumentation.fieldWithPath("data.nickname")
+                            .description("유저 닉네임"),
+                        PayloadDocumentation.fieldWithPath("data.position")
+                            .description("유저가 설정한 직군(포지션)"),
                         PayloadDocumentation.fieldWithPath("data.point")
-                            .description("유저 능력치 포인트(레벨 결정)")
+                            .description("유저가 설정한 직군에 대한 능력치 포인트(레벨 결정)")
+                    )
+                )
+            )
+    }
+
+    @GiljobTestUser
+    @Test
+    fun getUserProfileTest() {
+        BDDMockito.given(userService.getUserProfile(1L)).willReturn(
+            DtoFactory.testUserProfileResponse()
+        )
+
+        val result = mockMvc.perform(
+            RestDocumentationRequestBuilders.get("/api/users/{userId}/profile", 1L)
+        ).andDo(MockMvcResultHandlers.print())
+
+        result
+            .andExpect(MockMvcResultMatchers.status().isOk)
+            .andDo(
+                MockMvcRestDocumentation.document(
+                    "users/{userId}/profile/get",
+                    HeaderDocumentation.responseHeaders(),
+                    HeaderDocumentation.responseHeaders(),
+                    PayloadDocumentation.responseFields(
+                        PayloadDocumentation.fieldWithPath("status")
+                            .description("200"),
+                        PayloadDocumentation.fieldWithPath("message")
+                            .description("성공 메세지"),
+                        PayloadDocumentation.fieldWithPath("data")
+                            .description("응답 데이터"),
+                        PayloadDocumentation.fieldWithPath("data.userInfo")
+                            .description("유저 정보 조회"),
+                        PayloadDocumentation.fieldWithPath("data.userInfo.userId")
+                            .description("유저 id"),
+                        PayloadDocumentation.fieldWithPath("data.userInfo.nickname")
+                            .description("유저 닉네임"),
+                        PayloadDocumentation.fieldWithPath("data.userInfo.position")
+                            .description("유저가 설정한 직군(포지션)"),
+                        PayloadDocumentation.fieldWithPath("data.userInfo.point")
+                            .description("유저가 설정한 직군에 대한 능력치 포인트"),
+                        PayloadDocumentation.fieldWithPath("data.intro")
+                            .description("유저 자기소개"),
+                        PayloadDocumentation.fieldWithPath("data.abilityList")
+                            .description("유저 능력치 리스트"),
+                        PayloadDocumentation.fieldWithPath("data.abilityList[*].position")
+                            .description("유저 포지션"),
+                        PayloadDocumentation.fieldWithPath("data.abilityList[*].point")
+                            .description("유저 포지션에 대한 포인트"),
                     )
                 )
             )

--- a/src/test/kotlin/com/yapp/giljob/domain/user/api/UserControllerTest.kt
+++ b/src/test/kotlin/com/yapp/giljob/domain/user/api/UserControllerTest.kt
@@ -62,7 +62,9 @@ class UserControllerTest : AbstractRestDocs() {
                         PayloadDocumentation.fieldWithPath("data.position")
                             .description("유저가 설정한 직군(포지션)"),
                         PayloadDocumentation.fieldWithPath("data.point")
-                            .description("유저가 설정한 직군에 대한 능력치 포인트(레벨 결정)")
+                            .description("유저가 설정한 직군에 대한 능력치 포인트(레벨 결정)"),
+                        PayloadDocumentation.fieldWithPath("data.intro")
+                            .description("유저 자기소개")
                     )
                 )
             )
@@ -103,7 +105,7 @@ class UserControllerTest : AbstractRestDocs() {
                             .description("유저가 설정한 직군(포지션)"),
                         PayloadDocumentation.fieldWithPath("data.userInfo.point")
                             .description("유저가 설정한 직군에 대한 능력치 포인트"),
-                        PayloadDocumentation.fieldWithPath("data.intro")
+                        PayloadDocumentation.fieldWithPath("data.userInfo.intro")
                             .description("유저 자기소개"),
                         PayloadDocumentation.fieldWithPath("data.abilityList")
                             .description("유저 능력치 리스트"),

--- a/src/test/kotlin/com/yapp/giljob/domain/user/application/UserQuestServiceTest.kt
+++ b/src/test/kotlin/com/yapp/giljob/domain/user/application/UserQuestServiceTest.kt
@@ -4,7 +4,6 @@ import com.yapp.giljob.domain.quest.application.QuestMapper
 import com.yapp.giljob.domain.quest.dao.QuestParticipationRepository
 import com.yapp.giljob.domain.quest.dao.QuestRepository
 import com.yapp.giljob.domain.subquest.dao.SubQuestParticipationRepository
-import com.yapp.giljob.domain.user.dao.UserMapper
 import io.mockk.MockKAnnotations
 import io.mockk.impl.annotations.MockK
 import org.junit.jupiter.api.Assertions.*

--- a/src/test/kotlin/com/yapp/giljob/global/common/dto/DtoFactory.kt
+++ b/src/test/kotlin/com/yapp/giljob/global/common/dto/DtoFactory.kt
@@ -7,10 +7,13 @@ import com.yapp.giljob.domain.quest.dto.response.QuestByParticipantResponseDto
 import com.yapp.giljob.domain.sign.dto.request.SignInRequestDto
 import com.yapp.giljob.domain.sign.dto.request.SignUpRequestDto
 import com.yapp.giljob.domain.tag.dto.response.TagResponseDto
-import com.yapp.giljob.domain.user.vo.UserSubDto
+import com.yapp.giljob.domain.user.dto.response.UserSubResponseDto
 import com.yapp.giljob.domain.quest.dto.response.QuestDetailCommonResponseDto
 import com.yapp.giljob.domain.subquest.dto.request.SubQuestRequestDto
 import com.yapp.giljob.domain.tag.dto.request.TagRequestDto
+import com.yapp.giljob.domain.user.dto.response.AbilityResponseDto
+import com.yapp.giljob.domain.user.dto.response.UserInfoResponseDto
+import com.yapp.giljob.domain.user.dto.response.UserProfileResponseDto
 import com.yapp.giljob.infra.s3.dto.responsne.S3UploadResponseDto
 
 class DtoFactory {
@@ -32,7 +35,7 @@ class DtoFactory {
             difficulty = 1,
             thumbnail = "test.png",
             participantCount = 100,
-            user = UserSubDto(
+            user = UserSubResponseDto(
                 id = 1L,
                 nickname = "testNickname",
                 point = 100
@@ -46,7 +49,7 @@ class DtoFactory {
             difficulty = 1,
             thumbnail = "test.png",
             participantCount = 100,
-            user = UserSubDto(
+            user = UserSubResponseDto(
                 id = 1L,
                 nickname = "testNickname",
                 point = 100
@@ -70,12 +73,29 @@ class DtoFactory {
             kakaoAccessToken = "test",
             position = Position.BACKEND.name,
             intro = "testIntro",
-            nickname = "nickname")
+            nickname = "nickname"
+        )
 
         fun testSignInRequest() = SignInRequestDto(kakaoAccessToken = "test")
 
         fun testS3UploadResponse() = S3UploadResponseDto(
             fileUrl = "https://giljob.s3.us-east-2.amazonaws.com/0f792d8f-8fc0-49c6-ba39-b77d39024239test.jpeg"
+        )
+
+        fun testUserInfoResponse() = UserInfoResponseDto(
+            userId = 1L,
+            nickname = "nickname",
+            position = Position.BACKEND,
+            point = 1000L
+        )
+
+        fun testUserProfileResponse() = UserProfileResponseDto(
+            userInfo = testUserInfoResponse(),
+            intro = "test introduce",
+            abilityList = mutableListOf(
+                AbilityResponseDto(Position.BACKEND, 1000L),
+                AbilityResponseDto(Position.FRONTEND, 400L)
+            )
         )
 
     }

--- a/src/test/kotlin/com/yapp/giljob/global/common/dto/DtoFactory.kt
+++ b/src/test/kotlin/com/yapp/giljob/global/common/dto/DtoFactory.kt
@@ -86,12 +86,12 @@ class DtoFactory {
             userId = 1L,
             nickname = "nickname",
             position = Position.BACKEND,
-            point = 1000L
+            point = 1000L,
+            intro = "test introduce"
         )
 
         fun testUserProfileResponse() = UserProfileResponseDto(
             userInfo = testUserInfoResponse(),
-            intro = "test introduce",
             abilityList = mutableListOf(
                 AbilityResponseDto(Position.BACKEND, 1000L),
                 AbilityResponseDto(Position.FRONTEND, 400L)


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/69340410/145213307-a299a830-ae20-4cb2-9fa6-f2e9af24690c.png)

![image](https://user-images.githubusercontent.com/69340410/145213107-4af51d44-fc1d-49db-99d0-296c63a37c39.png)


유저 공통 정보를 userInfo로 설정했습니다. -> userInfo 필드는 **인증된 유저 정보 조회**의 응답 필드도 수정했어요!

intro 필드도 userInfo 안에 공통으로 넣는 게 좋을지 고민 중입니다..  intro도 user 테이블의 컬럼이어서 공통으로 넣어도 될 것 같은데..
지은님 의견이 궁금해요!
일단은 프로필 페이지 보고 intro는 따로 빼놨습니담

그리고 업적 관련 필드는 아직 안 넣어놨어요!! 
업적 관련해서 대표 업적은 뭐로 할지 얘기하고 넣으면 좋을 듯해서요!! 아직 항해 업적 조회도 구현 안해서 그때 같이 해도 좋을 것 같아요~~
