### PR TITLE
[GILJOB-96] 내 정보, 자기소개 수정 api

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -11,8 +11,8 @@ Andy Wilkinson;
 === POST /api/quests
 .request
 include::{snippets}/quests/post/http-request.adoc[]
-.response
-include::{snippets}/quests/post/http-response.adoc[]
+.request
+include::{snippets}/quests/post/request-fields.adoc[]
 .response
 include::{snippets}/quests/post/response-body.adoc[]
 .response fields
@@ -53,22 +53,22 @@ include::{snippets}/quests/common/get/response-fields.adoc[]
 
 .request
 include::{snippets}/quests/participation/post/http-request.adoc[]
-.response
-include::{snippets}/quests/participation/post/http-response.adoc[]
 .request fields
 include::{snippets}/quests/participation/post/path-parameters.adoc[]
+.response
+include::{snippets}/quests/participation/post/http-response.adoc[]
 .response fields
 include::{snippets}/quests/participation/post/response-fields.adoc[]
 
-=== Patch /api/quests/{questId}/complete
+=== PATCH /api/quests/{questId}/complete
 퀘스트 완료
 
 .request
 include::{snippets}/quests/{questId}/complete/patch/http-request.adoc[]
-.response
-include::{snippets}/quests/{questId}/complete/patch/http-response.adoc[]
 .request fields
 include::{snippets}/quests/{questId}/participation/post/path-parameters.adoc[]
+.response
+include::{snippets}/quests/{questId}/complete/patch/http-response.adoc[]
 .response fields
 include::{snippets}/quests/{questId}/complete/patch/response-fields.adoc[]
 
@@ -100,8 +100,8 @@ include::{snippets}/users/{userId}/quests/participation/get/response-fields.adoc
 
 .request
 include::{snippets}/subquests/post/http-request.adoc[]
-.response
-include::{snippets}/subquests/post/http-response.adoc[]
+.request
+include::{snippets}/subquests/post/path-parameters.adoc[]
 .response
 include::{snippets}/subquests/post/response-body.adoc[]
 .response fields

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -136,17 +136,17 @@ include::{snippets}/users/me/get/http-response.adoc[]
 .response fields
 include::{snippets}/users/me/get/response-fields.adoc[]
 
-=== PATCH /api/users/me/info
+=== PATCH /api/users/me
 유저 정보 수정
 
 .request
-include::{snippets}/users/me/info/patch/http-request.adoc[]
+include::{snippets}/users/me/patch/http-request.adoc[]
 .request
-include::{snippets}/users/me/info/patch/request-fields.adoc[]
+include::{snippets}/users/me/patch/request-fields.adoc[]
 .response
-include::{snippets}/users/me/info/patch/response-body.adoc[]
+include::{snippets}/users/me/patch/response-body.adoc[]
 .response fields
-include::{snippets}/users/me/info/patch/response-fields.adoc[]
+include::{snippets}/users/me/patch/response-fields.adoc[]
 
 === PATCH /api/users/me/intro
 유저 자기소개 수정

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -136,6 +136,30 @@ include::{snippets}/users/me/get/http-response.adoc[]
 .response fields
 include::{snippets}/users/me/get/response-fields.adoc[]
 
+=== PATCH /api/users/me/info
+유저 정보 수정
+
+.request
+include::{snippets}/users/me/info/patch/http-request.adoc[]
+.request
+include::{snippets}/users/me/info/patch/request-fields.adoc[]
+.response
+include::{snippets}/users/me/info/patch/response-body.adoc[]
+.response fields
+include::{snippets}/users/me/info/patch/response-fields.adoc[]
+
+=== PATCH /api/users/me/intro
+유저 자기소개 수정
+
+.request
+include::{snippets}/users/me/intro/patch/http-request.adoc[]
+.request
+include::{snippets}/users/me/intro/patch/request-fields.adoc[]
+.response
+include::{snippets}/users/me/intro/patch/response-body.adoc[]
+.response fields
+include::{snippets}/users/me/intro/patch/response-fields.adoc[]
+
 == Upload API
 === POST /api/upload
 .request

--- a/src/main/kotlin/com/yapp/giljob/domain/user/api/UserController.kt
+++ b/src/main/kotlin/com/yapp/giljob/domain/user/api/UserController.kt
@@ -3,6 +3,7 @@ package com.yapp.giljob.domain.user.api
 import com.yapp.giljob.domain.user.application.UserService
 import com.yapp.giljob.domain.user.domain.User
 import com.yapp.giljob.domain.user.dto.request.UserInfoUpdateRequestDto
+import com.yapp.giljob.domain.user.dto.request.UserIntroUpdateRequestDto
 import com.yapp.giljob.domain.user.dto.response.UserInfoResponseDto
 import com.yapp.giljob.global.common.annotation.CurrentUser
 import com.yapp.giljob.global.common.dto.BaseResponse
@@ -26,11 +27,27 @@ class UserController(
     }
 
     @PatchMapping("/me/info")
-    fun updateUserInfo(@CurrentUser user: User, @RequestBody requestDto: UserInfoUpdateRequestDto): ResponseEntity<BaseResponse<Unit>> {
+    fun updateUserInfo(
+        @CurrentUser user: User,
+        @RequestBody requestDto: UserInfoUpdateRequestDto
+    ): ResponseEntity<BaseResponse<Unit>> {
         userService.updateUserInfo(user.id!!, requestDto)
         return ResponseEntity.ok(
             BaseResponse.of(
                 HttpStatus.OK, "유저 정보 업데이트 성공입니다."
+            )
+        )
+    }
+
+    @PatchMapping("/me/intro")
+    fun updateUserIntro(
+        @CurrentUser user: User,
+        @RequestBody requestDto: UserIntroUpdateRequestDto
+    ): ResponseEntity<BaseResponse<Unit>> {
+        userService.updateUserIntro(user.id!!, requestDto.intro)
+        return ResponseEntity.ok(
+            BaseResponse.of(
+                HttpStatus.OK, "유저 자기소개 업데이트 성공입니다."
             )
         )
     }

--- a/src/main/kotlin/com/yapp/giljob/domain/user/api/UserController.kt
+++ b/src/main/kotlin/com/yapp/giljob/domain/user/api/UserController.kt
@@ -26,7 +26,7 @@ class UserController(
         )
     }
 
-    @PatchMapping("/me/info")
+    @PatchMapping("/me")
     fun updateUserInfo(
         @CurrentUser user: User,
         @RequestBody requestDto: UserInfoUpdateRequestDto

--- a/src/main/kotlin/com/yapp/giljob/domain/user/api/UserController.kt
+++ b/src/main/kotlin/com/yapp/giljob/domain/user/api/UserController.kt
@@ -2,14 +2,13 @@ package com.yapp.giljob.domain.user.api
 
 import com.yapp.giljob.domain.user.application.UserService
 import com.yapp.giljob.domain.user.domain.User
+import com.yapp.giljob.domain.user.dto.request.UserInfoUpdateRequestDto
 import com.yapp.giljob.domain.user.dto.response.UserInfoResponseDto
 import com.yapp.giljob.global.common.annotation.CurrentUser
 import com.yapp.giljob.global.common.dto.BaseResponse
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.*
 
 @RestController
 @RequestMapping("/api/users")
@@ -22,6 +21,16 @@ class UserController(
             BaseResponse.of(
                 HttpStatus.OK, "인증된 유저 정보 조회 성공입니다.",
                 userService.getAuthenticatedUserInfo(user)
+            )
+        )
+    }
+
+    @PatchMapping("/me/info")
+    fun updateUserInfo(@CurrentUser user: User, @RequestBody requestDto: UserInfoUpdateRequestDto): ResponseEntity<BaseResponse<Unit>> {
+        userService.updateUserInfo(user.id!!, requestDto)
+        return ResponseEntity.ok(
+            BaseResponse.of(
+                HttpStatus.OK, "유저 정보 업데이트 성공입니다."
             )
         )
     }

--- a/src/main/kotlin/com/yapp/giljob/domain/user/application/UserService.kt
+++ b/src/main/kotlin/com/yapp/giljob/domain/user/application/UserService.kt
@@ -2,15 +2,19 @@ package com.yapp.giljob.domain.user.application
 
 import com.yapp.giljob.domain.position.domain.Position
 import com.yapp.giljob.domain.user.dao.AbilityRepository
+import com.yapp.giljob.domain.user.dao.UserRepository
 import com.yapp.giljob.domain.user.domain.User
+import com.yapp.giljob.domain.user.dto.request.UserInfoUpdateRequestDto
 import com.yapp.giljob.domain.user.dto.response.UserInfoResponseDto
 import com.yapp.giljob.global.error.ErrorCode
 import com.yapp.giljob.global.error.exception.BusinessException
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
 @Service
 class UserService(
+    private val userRepository: UserRepository,
     private val abilityRepository: AbilityRepository,
 ) {
     @Transactional(readOnly = true)
@@ -20,4 +24,11 @@ class UserService(
     private fun getUserAbility(userId: Long, position: Position) =
         abilityRepository.findByUserIdAndPosition(userId, position)
             ?: throw BusinessException(ErrorCode.ENTITY_NOT_FOUND)
+
+    @Transactional
+    fun updateUserInfo(userId: Long, requestDto: UserInfoUpdateRequestDto) {
+        val user = userRepository.findByIdOrNull(userId) ?: throw BusinessException(ErrorCode.ENTITY_NOT_FOUND)
+        user.nickname = requestDto.nickname
+        user.position = requestDto.position
+    }
 }

--- a/src/main/kotlin/com/yapp/giljob/domain/user/application/UserService.kt
+++ b/src/main/kotlin/com/yapp/giljob/domain/user/application/UserService.kt
@@ -28,7 +28,12 @@ class UserService(
     @Transactional
     fun updateUserInfo(userId: Long, requestDto: UserInfoUpdateRequestDto) {
         val user = userRepository.findByIdOrNull(userId) ?: throw BusinessException(ErrorCode.ENTITY_NOT_FOUND)
-        user.nickname = requestDto.nickname
-        user.position = requestDto.position
+        user.updateInfo(requestDto.nickname, requestDto.position)
+    }
+
+    @Transactional
+    fun updateUserIntro(userId: Long, intro: String) {
+        val user = userRepository.findByIdOrNull(userId) ?: throw BusinessException(ErrorCode.ENTITY_NOT_FOUND)
+        user.updateIntro(intro)
     }
 }

--- a/src/main/kotlin/com/yapp/giljob/domain/user/domain/User.kt
+++ b/src/main/kotlin/com/yapp/giljob/domain/user/domain/User.kt
@@ -9,7 +9,7 @@ import javax.persistence.*
 
 @Table(name = "user")
 @Entity
-class User (
+class User(
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "user_id")
     val id: Long? = null,
@@ -33,10 +33,19 @@ class User (
 
     override fun hashCode() = kotlinHashCode(properties = equalsAndHashCodeProperties)
 
+    fun updateInfo(nickname: String, position: Position) {
+        this.nickname = nickname
+        this.position = position
+    }
+
+    fun updateIntro(intro: String) {
+        this.intro = intro
+    }
+
     companion object {
         private val equalsAndHashCodeProperties = arrayOf(User::id)
 
-        fun of (signUpRequestDto: SignUpRequestDto, kakaoId: String): User {
+        fun of(signUpRequestDto: SignUpRequestDto, kakaoId: String): User {
             return User(
                 socialId = kakaoId,
                 nickname = signUpRequestDto.nickname,

--- a/src/main/kotlin/com/yapp/giljob/domain/user/dto/request/UserInfoUpdateRequestDto.kt
+++ b/src/main/kotlin/com/yapp/giljob/domain/user/dto/request/UserInfoUpdateRequestDto.kt
@@ -1,0 +1,8 @@
+package com.yapp.giljob.domain.user.dto.request
+
+import com.yapp.giljob.domain.position.domain.Position
+
+class UserInfoUpdateRequestDto(
+    val nickname: String,
+    val position: Position
+)

--- a/src/main/kotlin/com/yapp/giljob/domain/user/dto/request/UserIntroUpdateRequestDto.kt
+++ b/src/main/kotlin/com/yapp/giljob/domain/user/dto/request/UserIntroUpdateRequestDto.kt
@@ -1,0 +1,5 @@
+package com.yapp.giljob.domain.user.dto.request
+
+class UserIntroUpdateRequestDto(
+    val intro: String
+)

--- a/src/main/resources/static/docs/index.html
+++ b/src/main/resources/static/docs/index.html
@@ -478,6 +478,8 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <li><a href="#_user_api">User API</a>
 <ul class="sectlevel2">
 <li><a href="#_get_apiusersme">GET /api/users/me</a></li>
+<li><a href="#_patch_apiusersmeinfo">PATCH /api/users/me/info</a></li>
+<li><a href="#_patch_apiusersmeintro">PATCH /api/users/me/intro</a></li>
 </ul>
 </li>
 <li><a href="#_upload_api">Upload API</a>
@@ -1501,7 +1503,7 @@ Content-Length: 238
   "status" : 200,
   "message" : "회원 가입 성공입니다.",
   "data" : {
-    "accessToken" : "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJudWxsIiwiaWF0IjoxNjM4ODgwNTg2LCJleHAiOjI2Mzg4ODA1ODZ9.ubsN_wjir0JE4cf7AorMswlNiBejpGx85Va9-sKkHc4"
+    "accessToken" : "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJudWxsIiwiaWF0IjoxNjM4OTgxODA5LCJleHAiOjI2Mzg5ODE4MDl9.LeOHCWCAtD5vcMNnUu8LkOVjJVfK63pMMa7Nn_dcr8M"
   }
 }</code></pre>
 </div>
@@ -1571,7 +1573,7 @@ Content-Length: 266
   "message" : "로그인 및 조회 성공입니다.",
   "data" : {
     "isSignedUp" : true,
-    "accessToken" : "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIiwiaWF0IjoxNjM4ODgwNTg1LCJleHAiOjI2Mzg4ODA1ODV9.rQzcOyFtc-7HZOHlYr3Heh8baFAqhAzLcpIC_NbN9bA"
+    "accessToken" : "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIiwiaWF0IjoxNjM4OTgxODA5LCJleHAiOjI2Mzg5ODE4MDl9.pXboopmrWpBjzZDltPPrkgIm1tGKfwMttdHFkL4X7yM"
   }
 }</code></pre>
 </div>
@@ -1696,6 +1698,180 @@ Content-Length: 140
 </tbody>
 </table>
 </div>
+<div class="sect2">
+<h3 id="_patch_apiusersmeinfo"><a class="link" href="#_patch_apiusersmeinfo">PATCH /api/users/me/info</a></h3>
+<div class="paragraph">
+<p>유저 정보 수정</p>
+</div>
+<div class="listingblock">
+<div class="title">request</div>
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">PATCH /api/users/me/info HTTP/1.1
+Content-Type: application/json;charset=UTF-8
+Authorization: Access Token
+Content-Length: 59
+Host: docs.api.com:8080
+
+{
+  "nickname" : "testNickname",
+  "position" : "BACKEND"
+}</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<caption class="title">Table 16. request</caption>
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>nickname</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">수정할 닉네임</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>position</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">수정할 직군(BACKEND/FRONTEND)</p></td>
+</tr>
+</tbody>
+</table>
+<div class="listingblock">
+<div class="title">response</div>
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-none hljs">{
+  "status" : 200,
+  "message" : "유저 정보 업데이트 성공입니다.",
+  "data" : null
+}</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<caption class="title">Table 17. response fields</caption>
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>status</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">200</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>message</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">성공 메세지</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Null</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">null</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect2">
+<h3 id="_patch_apiusersmeintro"><a class="link" href="#_patch_apiusersmeintro">PATCH /api/users/me/intro</a></h3>
+<div class="paragraph">
+<p>유저 자기소개 수정</p>
+</div>
+<div class="listingblock">
+<div class="title">request</div>
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">PATCH /api/users/me/intro HTTP/1.1
+Content-Type: application/json;charset=UTF-8
+Authorization: Access Token
+Content-Length: 32
+Host: docs.api.com:8080
+
+{
+  "intro" : "test introduce"
+}</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<caption class="title">Table 18. request</caption>
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>intro</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">수정할 자기소개</p></td>
+</tr>
+</tbody>
+</table>
+<div class="listingblock">
+<div class="title">response</div>
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-none hljs">{
+  "status" : 200,
+  "message" : "유저 자기소개 업데이트 성공입니다.",
+  "data" : null
+}</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<caption class="title">Table 19. response fields</caption>
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>status</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">200</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>message</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">성공 메세지</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Null</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">null</p></td>
+</tr>
+</tbody>
+</table>
+</div>
 </div>
 </div>
 <div class="sect1">
@@ -1704,7 +1880,7 @@ Content-Length: 140
 <div class="sect2">
 <h3 id="_post_apiupload"><a class="link" href="#_post_apiupload">POST /api/upload</a></h3>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 16. request</caption>
+<caption class="title">Table 20. request</caption>
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -1751,7 +1927,7 @@ Content-Length: 198
 </div>
 </div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 17. response fields</caption>
+<caption class="title">Table 21. response fields</caption>
 <colgroup>
 <col style="width: 33.3333%;">
 <col style="width: 33.3333%;">
@@ -1794,7 +1970,7 @@ Content-Length: 198
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2021-12-07 07:59:35 +0900
+Last updated 2021-12-09 01:42:30 +0900
 </div>
 </div>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.6/styles/github.min.css">

--- a/src/main/resources/static/docs/index.html
+++ b/src/main/resources/static/docs/index.html
@@ -478,7 +478,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <li><a href="#_user_api">User API</a>
 <ul class="sectlevel2">
 <li><a href="#_get_apiusersme">GET /api/users/me</a></li>
-<li><a href="#_patch_apiusersmeinfo">PATCH /api/users/me/info</a></li>
+<li><a href="#_patch_apiusersme">PATCH /api/users/me</a></li>
 <li><a href="#_patch_apiusersmeintro">PATCH /api/users/me/intro</a></li>
 </ul>
 </li>
@@ -1524,14 +1524,13 @@ Host: docs.api.com:8080</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /sign-up HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Content-Length: 111
+Content-Length: 86
 Host: docs.api.com:8080
 
 {
   "kakaoAccessToken" : "test",
   "position" : "BACKEND",
-  "nickname" : "nickname",
-  "intro" : "testIntro"
+  "nickname" : "nickname"
 }</code></pre>
 </div>
 </div>
@@ -1539,55 +1538,13 @@ Host: docs.api.com:8080
 <div class="title">response</div>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
-Content-Type: application/json;charset=UTF-8
-Content-Length: 238
-
-{
-  "status" : 200,
-  "message" : "회원 가입 성공입니다.",
-  "data" : {
-    "accessToken" : "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJudWxsIiwiaWF0IjoxNjM4OTgyMTYyLCJleHAiOjI2Mzg5ODIxNjJ9.6AIXWMmpNcE_Nua6a_BW8YyStaSTlav5-G9PG5k5Cs4"
-  }
-}</code></pre>
+Authorization: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJudWxsIiwiaWF0IjoxNjM3NTgxMTcyLCJleHAiOjE2Mzc2ODExNzJ9.sMI-0THQUxlbQ6kR05Qr6SzQ2JUGWB-aw6RDMz0kG00</code></pre>
 </div>
 </div>
-<table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 15. response</caption>
-<colgroup>
-<col style="width: 33.3333%;">
-<col style="width: 33.3333%;">
-<col style="width: 33.3334%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">Path</th>
-<th class="tableblock halign-left valign-top">Type</th>
-<th class="tableblock halign-left valign-top">Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>status</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">200</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>message</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">성공 메세지</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Object</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">응답 데이터(퀘스트 리스트)</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.accessToken</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">애플리케이션 access token</p></td>
-</tr>
-</tbody>
-</table>
+<div class="paragraph">
+<div class="title">response</div>
+<p>Unresolved directive in index.adoc - include::/Users/jenny/Desktop/Dev/Web-Team-1-Backend/build/generated-snippets/sign-up/post/response-fields.adoc[]</p>
+</div>
 </div>
 <div class="sect2">
 <h3 id="_post_sign_in"><a class="link" href="#_post_sign_in">POST /sign-in</a></h3>
@@ -1608,61 +1565,13 @@ Host: docs.api.com:8080
 <div class="title">response</div>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
-Content-Type: application/json;charset=UTF-8
-Content-Length: 266
-
-{
-  "status" : 200,
-  "message" : "로그인 및 조회 성공입니다.",
-  "data" : {
-    "isSignedUp" : true,
-    "accessToken" : "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIiwiaWF0IjoxNjM4OTgyMTYyLCJleHAiOjI2Mzg5ODIxNjJ9.m7VZeORW1VKH6wNh-S2_YmfJ93iOjjwdMu-Mdt2VpGs"
-  }
-}</code></pre>
+Authorization: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIiwiaWF0IjoxNjM3NTgxMTcxLCJleHAiOjE2Mzc2ODExNzF9.p5K_cWbJeG-g2Cf1E_2SKeeZwCD9vw-IpMhnRaAEPwA</code></pre>
 </div>
 </div>
-<table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 16. response</caption>
-<colgroup>
-<col style="width: 33.3333%;">
-<col style="width: 33.3333%;">
-<col style="width: 33.3334%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">Path</th>
-<th class="tableblock halign-left valign-top">Type</th>
-<th class="tableblock halign-left valign-top">Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>status</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">200</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>message</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">성공 메세지</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Object</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">응답 데이터(퀘스트 리스트)</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.isSignedUp</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">회원 가입한 회원인지 여부, false이면 회원 가입 진행</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.accessToken</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">애플리케이션 access token</p></td>
-</tr>
-</tbody>
-</table>
+<div class="paragraph">
+<div class="title">response</div>
+<p>Unresolved directive in index.adoc - include::/Users/jenny/Desktop/Dev/Web-Team-1-Backend/build/generated-snippets/sign-in/post/response-fields.adoc[]</p>
+</div>
 </div>
 </div>
 </div>
@@ -1699,7 +1608,7 @@ Content-Length: 140
 </div>
 </div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 17. response fields</caption>
+<caption class="title">Table 15. response fields</caption>
 <colgroup>
 <col style="width: 33.3333%;">
 <col style="width: 33.3333%;">
@@ -1742,14 +1651,14 @@ Content-Length: 140
 </table>
 </div>
 <div class="sect2">
-<h3 id="_patch_apiusersmeinfo"><a class="link" href="#_patch_apiusersmeinfo">PATCH /api/users/me/info</a></h3>
+<h3 id="_patch_apiusersme"><a class="link" href="#_patch_apiusersme">PATCH /api/users/me</a></h3>
 <div class="paragraph">
 <p>유저 정보 수정</p>
 </div>
 <div class="listingblock">
 <div class="title">request</div>
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">PATCH /api/users/me/info HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">PATCH /api/users/me HTTP/1.1
 Content-Type: application/json;charset=UTF-8
 Authorization: Access Token
 Content-Length: 59
@@ -1762,7 +1671,7 @@ Host: docs.api.com:8080
 </div>
 </div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 18. request</caption>
+<caption class="title">Table 16. request</caption>
 <colgroup>
 <col style="width: 33.3333%;">
 <col style="width: 33.3333%;">
@@ -1799,7 +1708,7 @@ Host: docs.api.com:8080
 </div>
 </div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 19. response fields</caption>
+<caption class="title">Table 17. response fields</caption>
 <colgroup>
 <col style="width: 33.3333%;">
 <col style="width: 33.3333%;">
@@ -1851,7 +1760,7 @@ Host: docs.api.com:8080
 </div>
 </div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 20. request</caption>
+<caption class="title">Table 18. request</caption>
 <colgroup>
 <col style="width: 33.3333%;">
 <col style="width: 33.3333%;">
@@ -1883,7 +1792,7 @@ Host: docs.api.com:8080
 </div>
 </div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 21. response fields</caption>
+<caption class="title">Table 19. response fields</caption>
 <colgroup>
 <col style="width: 33.3333%;">
 <col style="width: 33.3333%;">
@@ -1923,7 +1832,7 @@ Host: docs.api.com:8080
 <div class="sect2">
 <h3 id="_post_apiupload"><a class="link" href="#_post_apiupload">POST /api/upload</a></h3>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 22. request</caption>
+<caption class="title">Table 20. request</caption>
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -1970,7 +1879,7 @@ Content-Length: 198
 </div>
 </div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 23. response fields</caption>
+<caption class="title">Table 21. response fields</caption>
 <colgroup>
 <col style="width: 33.3333%;">
 <col style="width: 33.3333%;">
@@ -2013,7 +1922,7 @@ Content-Length: 198
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2021-12-09 01:48:29 +0900
+Last updated 2021-12-09 19:28:34 +0900
 </div>
 </div>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.6/styles/github.min.css">

--- a/src/main/resources/static/docs/index.html
+++ b/src/main/resources/static/docs/index.html
@@ -455,7 +455,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <li><a href="#_get_apiquestscount">GET /api/quests/count</a></li>
 <li><a href="#_get_apiquestsquestidcommon">GET /api/quests/{questId}/common/</a></li>
 <li><a href="#_post_apiquestsquestidparticipation">POST /api/quests/{questId}/participation</a></li>
-<li><a href="#_patch_apiquestsquestidcomplete">Patch /api/quests/{questId}/complete</a></li>
+<li><a href="#_patch_apiquestsquestidcomplete">PATCH /api/quests/{questId}/complete</a></li>
 </ul>
 </li>
 <li><a href="#_user_quest_api">User Quest API</a>
@@ -522,20 +522,58 @@ Host: docs.api.com:8080
 }</code></pre>
 </div>
 </div>
-<div class="listingblock">
-<div class="title">response</div>
-<div class="content">
-<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
-Content-Type: application/json;charset=UTF-8
-Content-Length: 88
-
-{
-  "status" : 200,
-  "message" : "퀘스트 생성 성공입니다.",
-  "data" : null
-}</code></pre>
-</div>
-</div>
+<table class="tableblock frame-all grid-all stretch">
+<caption class="title">Table 1. request</caption>
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>name</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">퀘스트 이름</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>difficulty</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">퀘스트 난이도</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>position</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">카테고리(직군)</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>tagList[*].name</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">태그 이름</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>detail</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">상세 내용</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>thumbnail</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">썸네일 url</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>subQuestList[*].name</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">서브 퀘스트 이름</p></td>
+</tr>
+</tbody>
+</table>
 <div class="listingblock">
 <div class="title">response</div>
 <div class="content">
@@ -547,7 +585,7 @@ Content-Length: 88
 </div>
 </div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 1. response fields</caption>
+<caption class="title">Table 2. response fields</caption>
 <colgroup>
 <col style="width: 33.3333%;">
 <col style="width: 33.3333%;">
@@ -654,7 +692,7 @@ Content-Length: 1104
 </div>
 </div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 2. response fields</caption>
+<caption class="title">Table 3. response fields</caption>
 <colgroup>
 <col style="width: 33.3333%;">
 <col style="width: 33.3333%;">
@@ -762,7 +800,7 @@ Content-Length: 188
 </div>
 </div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 3. response fields</caption>
+<caption class="title">Table 4. response fields</caption>
 <colgroup>
 <col style="width: 33.3333%;">
 <col style="width: 33.3333%;">
@@ -815,7 +853,7 @@ Content-Length: 188
 <p>퀘스트 상세 페이지 공통 정보 조회</p>
 </div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 4. /api/quests/{questId}/common</caption>
+<caption class="title">Table 5. /api/quests/{questId}/common</caption>
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -856,7 +894,7 @@ Content-Length: 263
 </div>
 </div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 5. response fields</caption>
+<caption class="title">Table 6. response fields</caption>
 <colgroup>
 <col style="width: 33.3333%;">
 <col style="width: 33.3333%;">
@@ -931,22 +969,8 @@ Authorization: Access Token
 Host: docs.api.com:8080</code></pre>
 </div>
 </div>
-<div class="listingblock">
-<div class="title">response</div>
-<div class="content">
-<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
-Content-Type: application/json;charset=UTF-8
-Content-Length: 88
-
-{
-  "status" : 200,
-  "message" : "퀘스트 참여 성공입니다.",
-  "data" : null
-}</code></pre>
-</div>
-</div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 6. /api/quests/{questId}/participation</caption>
+<caption class="title">Table 7. /api/quests/{questId}/participation</caption>
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -964,8 +988,22 @@ Content-Length: 88
 </tr>
 </tbody>
 </table>
+<div class="listingblock">
+<div class="title">response</div>
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
+Content-Type: application/json;charset=UTF-8
+Content-Length: 88
+
+{
+  "status" : 200,
+  "message" : "퀘스트 참여 성공입니다.",
+  "data" : null
+}</code></pre>
+</div>
+</div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 7. response fields</caption>
+<caption class="title">Table 8. response fields</caption>
 <colgroup>
 <col style="width: 33.3333%;">
 <col style="width: 33.3333%;">
@@ -998,7 +1036,7 @@ Content-Length: 88
 </table>
 </div>
 <div class="sect2">
-<h3 id="_patch_apiquestsquestidcomplete"><a class="link" href="#_patch_apiquestsquestidcomplete">Patch /api/quests/{questId}/complete</a></h3>
+<h3 id="_patch_apiquestsquestidcomplete"><a class="link" href="#_patch_apiquestsquestidcomplete">PATCH /api/quests/{questId}/complete</a></h3>
 <div class="paragraph">
 <p>퀘스트 완료</p>
 </div>
@@ -1010,22 +1048,8 @@ Authorization: Access Token
 Host: docs.api.com:8080</code></pre>
 </div>
 </div>
-<div class="listingblock">
-<div class="title">response</div>
-<div class="content">
-<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
-Content-Type: application/json;charset=UTF-8
-Content-Length: 88
-
-{
-  "status" : 200,
-  "message" : "퀘스트 완료 성공입니다.",
-  "data" : null
-}</code></pre>
-</div>
-</div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 8. /api/quests/{questId}/participation</caption>
+<caption class="title">Table 9. /api/quests/{questId}/participation</caption>
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -1043,8 +1067,22 @@ Content-Length: 88
 </tr>
 </tbody>
 </table>
+<div class="listingblock">
+<div class="title">response</div>
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
+Content-Type: application/json;charset=UTF-8
+Content-Length: 88
+
+{
+  "status" : 200,
+  "message" : "퀘스트 완료 성공입니다.",
+  "data" : null
+}</code></pre>
+</div>
+</div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 9. response fields</caption>
+<caption class="title">Table 10. response fields</caption>
 <colgroup>
 <col style="width: 33.3333%;">
 <col style="width: 33.3333%;">
@@ -1156,7 +1194,7 @@ Content-Length: 1124
 </div>
 </div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 10. response fields</caption>
+<caption class="title">Table 11. response fields</caption>
 <colgroup>
 <col style="width: 33.3333%;">
 <col style="width: 33.3333%;">
@@ -1312,7 +1350,7 @@ Content-Length: 1208
 </div>
 </div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 11. response fields</caption>
+<caption class="title">Table 12. response fields</caption>
 <colgroup>
 <col style="width: 33.3333%;">
 <col style="width: 33.3333%;">
@@ -1412,20 +1450,25 @@ Authorization: Access Token
 Host: docs.api.com:8080</code></pre>
 </div>
 </div>
-<div class="listingblock">
-<div class="title">response</div>
-<div class="content">
-<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
-Content-Type: application/json;charset=UTF-8
-Content-Length: 94
-
-{
-  "status" : 200,
-  "message" : "서브퀘스트 완료 성공입니다.",
-  "data" : null
-}</code></pre>
-</div>
-</div>
+<table class="tableblock frame-all grid-all stretch">
+<caption class="title">Table 13. /api/subquests/{subQuestId}</caption>
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Parameter</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>subQuestId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">완료한 서브퀘스트 id</p></td>
+</tr>
+</tbody>
+</table>
 <div class="listingblock">
 <div class="title">response</div>
 <div class="content">
@@ -1437,7 +1480,7 @@ Content-Length: 94
 </div>
 </div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 12. response fields</caption>
+<caption class="title">Table 14. response fields</caption>
 <colgroup>
 <col style="width: 33.3333%;">
 <col style="width: 33.3333%;">
@@ -1503,13 +1546,13 @@ Content-Length: 238
   "status" : 200,
   "message" : "회원 가입 성공입니다.",
   "data" : {
-    "accessToken" : "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJudWxsIiwiaWF0IjoxNjM4OTgxODA5LCJleHAiOjI2Mzg5ODE4MDl9.LeOHCWCAtD5vcMNnUu8LkOVjJVfK63pMMa7Nn_dcr8M"
+    "accessToken" : "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJudWxsIiwiaWF0IjoxNjM4OTgyMTYyLCJleHAiOjI2Mzg5ODIxNjJ9.6AIXWMmpNcE_Nua6a_BW8YyStaSTlav5-G9PG5k5Cs4"
   }
 }</code></pre>
 </div>
 </div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 13. response</caption>
+<caption class="title">Table 15. response</caption>
 <colgroup>
 <col style="width: 33.3333%;">
 <col style="width: 33.3333%;">
@@ -1573,13 +1616,13 @@ Content-Length: 266
   "message" : "로그인 및 조회 성공입니다.",
   "data" : {
     "isSignedUp" : true,
-    "accessToken" : "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIiwiaWF0IjoxNjM4OTgxODA5LCJleHAiOjI2Mzg5ODE4MDl9.pXboopmrWpBjzZDltPPrkgIm1tGKfwMttdHFkL4X7yM"
+    "accessToken" : "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIiwiaWF0IjoxNjM4OTgyMTYyLCJleHAiOjI2Mzg5ODIxNjJ9.m7VZeORW1VKH6wNh-S2_YmfJ93iOjjwdMu-Mdt2VpGs"
   }
 }</code></pre>
 </div>
 </div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 14. response</caption>
+<caption class="title">Table 16. response</caption>
 <colgroup>
 <col style="width: 33.3333%;">
 <col style="width: 33.3333%;">
@@ -1656,7 +1699,7 @@ Content-Length: 140
 </div>
 </div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 15. response fields</caption>
+<caption class="title">Table 17. response fields</caption>
 <colgroup>
 <col style="width: 33.3333%;">
 <col style="width: 33.3333%;">
@@ -1719,7 +1762,7 @@ Host: docs.api.com:8080
 </div>
 </div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 16. request</caption>
+<caption class="title">Table 18. request</caption>
 <colgroup>
 <col style="width: 33.3333%;">
 <col style="width: 33.3333%;">
@@ -1756,7 +1799,7 @@ Host: docs.api.com:8080
 </div>
 </div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 17. response fields</caption>
+<caption class="title">Table 19. response fields</caption>
 <colgroup>
 <col style="width: 33.3333%;">
 <col style="width: 33.3333%;">
@@ -1808,7 +1851,7 @@ Host: docs.api.com:8080
 </div>
 </div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 18. request</caption>
+<caption class="title">Table 20. request</caption>
 <colgroup>
 <col style="width: 33.3333%;">
 <col style="width: 33.3333%;">
@@ -1840,7 +1883,7 @@ Host: docs.api.com:8080
 </div>
 </div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 19. response fields</caption>
+<caption class="title">Table 21. response fields</caption>
 <colgroup>
 <col style="width: 33.3333%;">
 <col style="width: 33.3333%;">
@@ -1880,7 +1923,7 @@ Host: docs.api.com:8080
 <div class="sect2">
 <h3 id="_post_apiupload"><a class="link" href="#_post_apiupload">POST /api/upload</a></h3>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 20. request</caption>
+<caption class="title">Table 22. request</caption>
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -1927,7 +1970,7 @@ Content-Length: 198
 </div>
 </div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 21. response fields</caption>
+<caption class="title">Table 23. response fields</caption>
 <colgroup>
 <col style="width: 33.3333%;">
 <col style="width: 33.3333%;">
@@ -1970,7 +2013,7 @@ Content-Length: 198
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2021-12-09 01:42:30 +0900
+Last updated 2021-12-09 01:48:29 +0900
 </div>
 </div>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.6/styles/github.min.css">

--- a/src/test/kotlin/com/yapp/giljob/domain/user/api/UserControllerTest.kt
+++ b/src/test/kotlin/com/yapp/giljob/domain/user/api/UserControllerTest.kt
@@ -73,7 +73,7 @@ class UserControllerTest : AbstractRestDocs() {
         val request = DtoFactory.testUserInfoRequest()
         val jsonString = ObjectMapper().writeValueAsString(request)
         val result = mockMvc.perform(
-            RestDocumentationRequestBuilders.patch("/api/users/me/info")
+            RestDocumentationRequestBuilders.patch("/api/users/me")
                 .header("Authorization", "Access Token")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(jsonString)
@@ -83,7 +83,7 @@ class UserControllerTest : AbstractRestDocs() {
             .andExpect(MockMvcResultMatchers.status().isOk)
             .andDo(
                 MockMvcRestDocumentation.document(
-                    "users/me/info/patch",
+                    "users/me/patch",
                     HeaderDocumentation.responseHeaders(),
                     HeaderDocumentation.responseHeaders(),
                     PayloadDocumentation.requestFields(

--- a/src/test/kotlin/com/yapp/giljob/domain/user/api/UserControllerTest.kt
+++ b/src/test/kotlin/com/yapp/giljob/domain/user/api/UserControllerTest.kt
@@ -1,17 +1,19 @@
 package com.yapp.giljob.domain.user.api
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import com.yapp.giljob.domain.user.application.UserService
 import com.yapp.giljob.domain.user.dao.AbilityRepository
 import com.yapp.giljob.domain.user.dao.UserRepository
 import com.yapp.giljob.domain.user.dto.response.UserInfoResponseDto
 import com.yapp.giljob.global.AbstractRestDocs
 import com.yapp.giljob.global.common.domain.EntityFactory
+import com.yapp.giljob.global.common.dto.DtoFactory
 import com.yapp.giljob.global.config.security.GiljobTestUser
 import org.junit.jupiter.api.Test
-import org.mockito.ArgumentMatchers.any
 import org.mockito.BDDMockito
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
 import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.http.MediaType
 import org.springframework.restdocs.headers.HeaderDocumentation
 import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation
 import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders
@@ -60,6 +62,78 @@ class UserControllerTest : AbstractRestDocs() {
                             .description("현재 유저 id"),
                         PayloadDocumentation.fieldWithPath("data.point")
                             .description("유저 능력치 포인트(레벨 결정)")
+                    )
+                )
+            )
+    }
+
+    @GiljobTestUser
+    @Test
+    fun updateUserInfoTest() {
+        val request = DtoFactory.testUserInfoRequest()
+        val jsonString = ObjectMapper().writeValueAsString(request)
+        val result = mockMvc.perform(
+            RestDocumentationRequestBuilders.patch("/api/users/me/info")
+                .header("Authorization", "Access Token")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(jsonString)
+        ).andDo(MockMvcResultHandlers.print())
+
+        result
+            .andExpect(MockMvcResultMatchers.status().isOk)
+            .andDo(
+                MockMvcRestDocumentation.document(
+                    "users/me/info/patch",
+                    HeaderDocumentation.responseHeaders(),
+                    HeaderDocumentation.responseHeaders(),
+                    PayloadDocumentation.requestFields(
+                        PayloadDocumentation.fieldWithPath("nickname")
+                            .description("수정할 닉네임"),
+                        PayloadDocumentation.fieldWithPath("position")
+                            .description("수정할 직군(BACKEND/FRONTEND)"),
+                    ),
+                    PayloadDocumentation.responseFields(
+                        PayloadDocumentation.fieldWithPath("status")
+                            .description("200"),
+                        PayloadDocumentation.fieldWithPath("message")
+                            .description("성공 메세지"),
+                        PayloadDocumentation.fieldWithPath("data")
+                            .description("null")
+                    )
+                )
+            )
+    }
+
+    @GiljobTestUser
+    @Test
+    fun updateUserIntroTest() {
+        val request = DtoFactory.testUserIntroRequest()
+        val jsonString = ObjectMapper().writeValueAsString(request)
+        val result = mockMvc.perform(
+            RestDocumentationRequestBuilders.patch("/api/users/me/intro")
+                .header("Authorization", "Access Token")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(jsonString)
+        ).andDo(MockMvcResultHandlers.print())
+
+        result
+            .andExpect(MockMvcResultMatchers.status().isOk)
+            .andDo(
+                MockMvcRestDocumentation.document(
+                    "users/me/intro/patch",
+                    HeaderDocumentation.responseHeaders(),
+                    HeaderDocumentation.responseHeaders(),
+                    PayloadDocumentation.requestFields(
+                        PayloadDocumentation.fieldWithPath("intro")
+                            .description("수정할 자기소개"),
+                    ),
+                    PayloadDocumentation.responseFields(
+                        PayloadDocumentation.fieldWithPath("status")
+                            .description("200"),
+                        PayloadDocumentation.fieldWithPath("message")
+                            .description("성공 메세지"),
+                        PayloadDocumentation.fieldWithPath("data")
+                            .description("null")
                     )
                 )
             )

--- a/src/test/kotlin/com/yapp/giljob/global/common/dto/DtoFactory.kt
+++ b/src/test/kotlin/com/yapp/giljob/global/common/dto/DtoFactory.kt
@@ -11,6 +11,8 @@ import com.yapp.giljob.domain.user.vo.UserSubDto
 import com.yapp.giljob.domain.quest.dto.response.QuestDetailCommonResponseDto
 import com.yapp.giljob.domain.subquest.dto.request.SubQuestRequestDto
 import com.yapp.giljob.domain.tag.dto.request.TagRequestDto
+import com.yapp.giljob.domain.user.dto.request.UserInfoUpdateRequestDto
+import com.yapp.giljob.domain.user.dto.request.UserIntroUpdateRequestDto
 import com.yapp.giljob.infra.s3.dto.responsne.S3UploadResponseDto
 
 class DtoFactory {
@@ -78,5 +80,13 @@ class DtoFactory {
             fileUrl = "https://giljob.s3.us-east-2.amazonaws.com/0f792d8f-8fc0-49c6-ba39-b77d39024239test.jpeg"
         )
 
+        fun testUserInfoRequest() = UserInfoUpdateRequestDto(
+            nickname = "testNickname",
+            position = Position.BACKEND
+        )
+
+        fun testUserIntroRequest() = UserIntroUpdateRequestDto(
+            intro = "test introduce"
+        )
     }
 }


### PR DESCRIPTION
- [PATCH] /api/users/me/info : 내 정보(닉네임, 포지션) 수정
- [PATCH] /api/users/me/intro : 자기소개 수정

닉네임, 직군 / 자기소개 이렇게 나눠서 수정하는 버튼이 있어서 2개로 api 구현했어요!

++ request fields 추가해서 api 문서 업데이트 했습니다!

api uri에 대해 사소한 고민이 있는데 요건 따로 얘기해용~~!😆

![image](https://user-images.githubusercontent.com/69340410/145249704-6f9e3fc9-032e-4362-a5ea-c4dde4b2a6bc.png)

![image](https://user-images.githubusercontent.com/69340410/145251092-c274f22c-04e7-44c6-8d30-5edbfc808d3e.png)
![image](https://user-images.githubusercontent.com/69340410/145251137-40c693e3-1f96-4ee6-9c6c-b45daf882b1a.png)

