### PR TITLE
[GILJOB-146] 태그 이름 null로 조회되는 이슈 해결

### DIFF
--- a/src/main/kotlin/com/yapp/giljob/domain/quest/application/QuestService.kt
+++ b/src/main/kotlin/com/yapp/giljob/domain/quest/application/QuestService.kt
@@ -8,10 +8,12 @@ import com.yapp.giljob.domain.quest.dto.request.QuestSaveRequestDto
 import com.yapp.giljob.domain.quest.dto.response.QuestDetailInfoResponseDto
 import com.yapp.giljob.domain.quest.dto.response.QuestPositionCountResponseDto
 import com.yapp.giljob.domain.quest.dto.response.QuestResponseDto
+import com.yapp.giljob.domain.quest.vo.QuestSupportVo
 import com.yapp.giljob.domain.roadmap.domain.Roadmap
 import com.yapp.giljob.domain.roadmap.domain.RoadmapQuest
 import com.yapp.giljob.domain.subquest.application.SubQuestService
 import com.yapp.giljob.domain.tag.application.TagService
+import com.yapp.giljob.domain.tag.dto.response.TagResponseDto
 import com.yapp.giljob.domain.user.application.UserMapper
 import com.yapp.giljob.domain.user.domain.User
 import com.yapp.giljob.global.error.ErrorCode
@@ -53,10 +55,7 @@ class QuestService(
     fun getQuestDetailInfo(questId: Long): QuestDetailInfoResponseDto {
         val questSupportVo =
             questRepository.findByQuestId(questId) ?: throw BusinessException(ErrorCode.ENTITY_NOT_FOUND)
-        return questMapper.toQuestDetailInfoDto(
-            questSupportVo,
-            userMapper.toDto(questSupportVo.quest.user, questSupportVo.point)
-        )
+        return convertToQuestDetailInfo(questSupportVo)
     }
 
     fun convertToQuestList(roadmap: Roadmap, questList: List<QuestRequestDto>): List<RoadmapQuest> {
@@ -85,6 +84,17 @@ class QuestService(
         }
 
         return roadmapQuestList
+    }
+
+    private fun convertToQuestDetailInfo(questSupportVo: QuestSupportVo): QuestDetailInfoResponseDto {
+        val questDetailInfoResponseDto = questMapper.toQuestDetailInfoDto(
+            questSupportVo,
+            userMapper.toDto(questSupportVo.quest.user, questSupportVo.point)
+        )
+        questDetailInfoResponseDto.tagList = questSupportVo.quest.tagList.map {
+            TagResponseDto(it.tag.name)
+        }
+        return questDetailInfoResponseDto
     }
 
     fun getQuestPositionCount(): List<QuestPositionCountResponseDto> {

--- a/src/main/kotlin/com/yapp/giljob/domain/quest/dao/QuestSupportRepositoryImpl.kt
+++ b/src/main/kotlin/com/yapp/giljob/domain/quest/dao/QuestSupportRepositoryImpl.kt
@@ -12,6 +12,8 @@ import com.yapp.giljob.domain.position.domain.Position
 import com.yapp.giljob.domain.quest.domain.QQuestParticipation.questParticipation
 import com.yapp.giljob.domain.quest.vo.QuestPositionCountVo
 import com.yapp.giljob.domain.quest.vo.QuestSupportVo
+import com.yapp.giljob.domain.tag.domain.QQuestTag.questTag
+import com.yapp.giljob.domain.tag.domain.QTag.tag
 import com.yapp.giljob.domain.user.domain.QUser.user
 
 class QuestSupportRepositoryImpl(
@@ -92,7 +94,9 @@ class QuestSupportRepositoryImpl(
         ).distinct()
             .from(quest)
             .where(quest.id.eq(questId))
+            .leftJoin(quest.user, user).fetchJoin()
             .leftJoin(ability).on(ability.position.eq(quest.user.position).and(ability.user.id.eq(quest.user.id)))
+            .leftJoin(questTag).on(questTag.quest.eq(quest)).fetchJoin()
             .fetchOne()
     }
 

--- a/src/main/kotlin/com/yapp/giljob/domain/tag/domain/QuestTag.kt
+++ b/src/main/kotlin/com/yapp/giljob/domain/tag/domain/QuestTag.kt
@@ -16,7 +16,7 @@ class QuestTag(
     @JoinColumn(name = "quest_id")
     val quest: Quest,
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne
     @JoinColumn(name = "tag_id")
     val tag: Tag
 ) {


### PR DESCRIPTION
`QuestDetailInfoResponseDto`의 tagList가 매핑이 되지 않아서 QuestService의 `convertToQuestDetailInfo` 메서드로 직접 매핑했어요. convert하는 메서드는 리팩토링할 때 분리해볼게요..! 
Mapstruct가 편하긴 한데 매핑 안되는 경우가 종종 있어서 힘드네요 ㅠㅠ.. 후에 Converter, Mapper 이 두 개 합치면 좋을 것 같아요!