### PR TITLE
[GILJOB-144] 퀘스트 리뷰 작성 api 문서 PATCH로 수정

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -107,7 +107,7 @@ include::{snippets}/quests/{questId}/complete/patch/http-response.adoc[]
 .response fields
 include::{snippets}/quests/{questId}/complete/patch/response-fields.adoc[]
 
-=== POST /api/quests/{questId}/review
+=== PATCH /api/quests/{questId}/review
 ==== 퀘스트 한줄 후기 작성
 
 .request

--- a/src/main/kotlin/com/yapp/giljob/domain/quest/application/QuestParticipationService.kt
+++ b/src/main/kotlin/com/yapp/giljob/domain/quest/application/QuestParticipationService.kt
@@ -86,10 +86,10 @@ class QuestParticipationService(
     ) {
         val questParticipation: QuestParticipation =
             questParticipationRepository.findByQuestIdAndParticipantId(questId, user.id!!)
-                ?: throw BusinessException(ErrorCode.ENTITY_NOT_FOUND)
+                ?: throw BusinessException(ErrorCode.NOT_COMPLETED_QUEST)
 
         if (!questParticipation.isCompleted) {
-            throw BusinessException(ErrorCode.CAN_NOT_CREATE_QUEST_REVIEW)
+            throw BusinessException(ErrorCode.NOT_COMPLETED_QUEST)
         }
 
         questParticipation.review = questReviewCreateRequestDto.review

--- a/src/main/kotlin/com/yapp/giljob/global/error/ErrorCode.kt
+++ b/src/main/kotlin/com/yapp/giljob/global/error/ErrorCode.kt
@@ -27,7 +27,6 @@ enum class ErrorCode(
     ALREADY_PARTICIPATED_QUEST(HttpStatus.BAD_REQUEST, "Q001", "Already Participated Quest"),
     ALREADY_COMPLETED_QUEST(HttpStatus.BAD_REQUEST, "Q002", "Already Completed Quest"),
     NOT_COMPLETED_QUEST(HttpStatus.BAD_REQUEST, "Q003", "Not Completed Quest"),
-    CAN_NOT_CREATE_QUEST_REVIEW(HttpStatus.BAD_REQUEST, "Q004", "Can Not Create Quest Review"),
 
     // SubQuest
     ALREADY_COMPLETED_SUBQUEST(HttpStatus.BAD_REQUEST, "SQ001", "Already Completed SubQuest"),

--- a/src/main/resources/static/docs/index.html
+++ b/src/main/resources/static/docs/index.html
@@ -496,7 +496,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <li><a href="#_퀘스트_완료">퀘스트 완료</a></li>
 </ul>
 </li>
-<li><a href="#_post_apiquestsquestidreview">POST /api/quests/{questId}/review</a>
+<li><a href="#_patch_apiquestsquestidreview">PATCH /api/quests/{questId}/review</a>
 <ul class="sectlevel3">
 <li><a href="#_퀘스트_한줄_후기_작성">퀘스트 한줄 후기 작성</a></li>
 </ul>
@@ -1518,7 +1518,7 @@ Content-Length: 88
 </div>
 </div>
 <div class="sect2">
-<h3 id="_post_apiquestsquestidreview"><a class="link" href="#_post_apiquestsquestidreview">POST /api/quests/{questId}/review</a></h3>
+<h3 id="_patch_apiquestsquestidreview"><a class="link" href="#_patch_apiquestsquestidreview">PATCH /api/quests/{questId}/review</a></h3>
 <div class="sect3">
 <h4 id="_퀘스트_한줄_후기_작성"><a class="link" href="#_퀘스트_한줄_후기_작성">퀘스트 한줄 후기 작성</a></h4>
 <div class="listingblock">
@@ -4012,7 +4012,7 @@ Content-Length: 198
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2022-01-10 14:53:45 +0900
+Last updated 2022-01-10 22:37:55 +0900
 </div>
 </div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.3/highlight.min.js"></script>

--- a/src/test/kotlin/com/yapp/giljob/domain/quest/application/QuestParticipationServiceTest.kt
+++ b/src/test/kotlin/com/yapp/giljob/domain/quest/application/QuestParticipationServiceTest.kt
@@ -207,7 +207,7 @@ class QuestParticipationServiceTest {
                 questParticipationService.createQuestReview(1L, questReviewCreateRequestDto, user)
             }
 
-        assertEquals(ErrorCode.ENTITY_NOT_FOUND, exception.errorCode)
+        assertEquals(ErrorCode.NOT_COMPLETED_QUEST, exception.errorCode)
     }
 
     @Test
@@ -220,6 +220,6 @@ class QuestParticipationServiceTest {
                 questParticipationService.createQuestReview(1L, questReviewCreateRequestDto, user)
             }
 
-        assertEquals(ErrorCode.CAN_NOT_CREATE_QUEST_REVIEW, exception.errorCode)
+        assertEquals(ErrorCode.NOT_COMPLETED_QUEST, exception.errorCode)
     }
 }


### PR DESCRIPTION
API 문서에서 퀘스트 리뷰 작성 POST로 되어 있던 부분 PATCH로 수정했습니다~

그리고 기존의 `ENTITY_NOT_FOUND` 에러 문구가 혼란을 줄 수 있어서 퀘스트 리뷰 작성시 퀘스트 미 참여나 아직 퀘스트 완료되지 않았을 경우 `NOT_COMPLETED_QUEST`로 통일했습니다